### PR TITLE
fix: have actual vocab open in a new tab

### DIFF
--- a/components/MainResults.vue
+++ b/components/MainResults.vue
@@ -28,8 +28,8 @@
           Namespace
         </h3>
         <p>
-          <a :href="model.iriSplitA" target="_blank">
-            {{ model.iriSplitA }}
+          <a :href="model.iriSplitA" >
+            {{ model.iriSplitA }} <span v-html="ExternalLink({ height: 15, width: 15 })"></span>
           </a>
         </p>
       </div>
@@ -48,6 +48,8 @@
 </template>
 
 <script>
+import { ExternalLink } from 'feather-icon-literals'
+
 export default {
   name: 'MainResults',
   props: {
@@ -65,7 +67,8 @@ export default {
       clipboardIri: {
         status: false,
         timeout: null
-      }
+      },
+      ExternalLink
     }
   },
   computed: {

--- a/components/MainResults.vue
+++ b/components/MainResults.vue
@@ -28,7 +28,7 @@
           Namespace
         </h3>
         <p>
-          <a :href="model.iriSplitA">
+          <a :href="model.iriSplitA" target="_blank">
             {{ model.iriSplitA }}
           </a>
         </p>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -78,7 +78,8 @@ export default {
     ** You can extend webpack config here
     */
     extend (config, ctx) {
-    }
+    },
+    transpile: ['feather-icon-literals']
   },
   hooks: {
     build: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5741,6 +5741,11 @@
         "pend": "~1.2.0"
       }
     },
+    "feather-icon-literals": {
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/feather-icon-literals/-/feather-icon-literals-1.0.0-rc.8.tgz",
+      "integrity": "sha512-JXMGWhxRyLPUaShuU6frFDhLWfBiE0l8pplmjZq9iO+zjZqeQ4Zw5nVj82fmRA3gTSLGA2DqxivBJg2SpA4f0Q=="
+    },
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "debug": "^4.1.1",
     "express": "^4.17.1",
     "express-preconditions": "^1.0.5",
+    "feather-icon-literals": "^1.0.0-rc.8",
     "fuse.js": "^3.4.5",
     "nuxt-start": "^2.8.1",
     "query-string": "^6.8.1",


### PR DESCRIPTION
I think that external link pointing to the namespace should open a new window