### PR TITLE
Kubernetes: make the deployment highly available

### DIFF
--- a/k8s/server/deployment.yaml
+++ b/k8s/server/deployment.yaml
@@ -3,7 +3,8 @@ kind: Deployment
 metadata:
   name: server
 spec:
-  replicas: 1
+  replicas: 2
+
   template:
     spec:
       securityContext:
@@ -33,3 +34,13 @@ spec:
             requests:
               memory: "250Mi"
               cpu: "50m"
+
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            # This makes sure the pods are not all scheduled on the same node
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels: {}
+                topologyKey: "kubernetes.io/hostname"

--- a/k8s/server/kustomization.yaml
+++ b/k8s/server/kustomization.yaml
@@ -7,3 +7,4 @@ commonLabels:
 resources:
   - deployment.yaml
   - service.yaml
+  - poddisruptionbudget.yaml

--- a/k8s/server/poddisruptionbudget.yaml
+++ b/k8s/server/poddisruptionbudget.yaml
@@ -1,0 +1,8 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: server
+spec:
+  selector:
+    matchLabels: {}
+  minAvailable: 1

--- a/k8s/varnish/deployment.yaml
+++ b/k8s/varnish/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: varnish
 spec:
+  replicas: 2
+
   template:
     spec:
       volumes:
@@ -35,3 +37,13 @@ spec:
             limits:
               memory: "150Mi"
               cpu: "50m"
+
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            # This makes sure the pods are not all scheduled on the same node
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels: {}
+                topologyKey: "kubernetes.io/hostname"

--- a/k8s/varnish/kustomization.yaml
+++ b/k8s/varnish/kustomization.yaml
@@ -7,6 +7,7 @@ commonLabels:
 resources:
   - deployment.yaml
   - service.yaml
+  - poddisruptionbudget.yaml
 
 configMapGenerator:
   - name: varnish-config

--- a/k8s/varnish/poddisruptionbudget.yaml
+++ b/k8s/varnish/poddisruptionbudget.yaml
@@ -1,0 +1,8 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: varnish
+spec:
+  selector:
+    matchLabels: {}
+  minAvailable: 1


### PR DESCRIPTION
This makes the deployment highly available by doing three things:

 - have 2 replicas of each pod
 - have those replicas spread across nodes ([pod anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity))
 - have a [PodDisruptionBudget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) to avoid having less than one replica

This is necessary for zero-downtime cluster upgrades