### PR TITLE
Kubernetes deployment: adjust CPU and memory limits

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -33,7 +33,10 @@ spec:
 
           resources:
             requests:
-              memory: "250Mi"
+              memory: "500Mi"
+              cpu: "50m"
+            limits:
+              memory: "500Mi"
               cpu: "50m"
 
         - name: varnish
@@ -55,8 +58,8 @@ spec:
 
           resources:
             requests:
-              memory: "50Mi"
-              cpu: "25m"
+              memory: "150Mi"
+              cpu: "50m"
             limits:
               memory: "150Mi"
               cpu: "50m"


### PR DESCRIPTION
Right now the app sits around 400Mb memory usage, which is a bit more than the current 250Mb requested.
Because there is no memory hard limit, it sometime gets randomly killed by the system OOM killer. By setting both limits and requests to 500Mb, it should guarantee the memory allocation for the app and properly reschedule it when a node is under memory pressure.