### PR TITLE
Ignore building Docker image for dependabot

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - "**"
-      - "!dependabot/*"
+      - "!dependabot/**"
     tags:
       - "v*.*.*"
 


### PR DESCRIPTION
Dependabot is creating branches with multiple level of `/`.
This requires to have two `*` in the wildcard to match them.