### PR TITLE
Create a `/api/v1/prefixes` route

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -90,6 +90,10 @@ router.get('/prefix', (req, res) => {
   })
 })
 
+router.get('/prefixes', (req, res) => {
+  res.json(Object.fromEntries(Object.entries(prefixMetadata).map(([prefix, value]) => [prefix, value.namespace])))
+})
+
 router.get('/summary', (req, res) => {
   res.json(summary)
 })

--- a/components/CurlExample.vue
+++ b/components/CurlExample.vue
@@ -15,7 +15,7 @@
       <div class="line">
         curl --silent \
         <br />
-        <a :href="url" target="_blank">"${DOMAIN}{{ path }}<span class="hl">?{{ query }}</span>"</a> \
+        <a :href="url" target="_blank">"${DOMAIN}{{ path }}<span v-if="query" class="hl">?{{ query }}</span>"</a> \
         <br />
         | jq .
       </div>

--- a/components/PageFooter.vue
+++ b/components/PageFooter.vue
@@ -20,7 +20,7 @@
         <span class="part">
           Copyright
           <a href="https://zazuko.com">Zazuko</a>
-          GmbH © 2022
+          GmbH © 2023
         </span>
       </div>
     </div>

--- a/pages/api.vue
+++ b/pages/api.vue
@@ -14,6 +14,7 @@
               <li><a href="#expand-endpoint"><code>/api/v1/expand?q=…</code></a></li>
               <li><a href="#shrink-endpoint"><code>/api/v1/shrink?q=…</code></a></li>
               <li><a href="#autocomplete-endpoint"><code>/api/v1/autocomplete?q=…</code></a></li>
+              <li><a href="#prefixes"><code>/api/v1/prefixes</code></a></li>
             </ul>
 
             <h2 id="expand-endpoint">
@@ -142,6 +143,33 @@
             <curl-example
               :url="apiPath('/api/v1/autocomplete', {q: 'rdfs:', type: 'rdf:Property' })"
               :result="['rdfs:comment','rdfs:domain','rdfs:isDefinedBy','rdfs:label','…']" />
+
+            <h2 id="prefixes">
+              Prefixes
+            </h2>
+
+            <p>
+              This endpoint returns the list of all known prefixes.
+              This can be used to implement a prefix selector.
+            </p>
+
+            <h3>Examples</h3>
+
+            <p>
+              How to get the list of all known prefixes:
+            </p>
+            <curl-example
+              :url="apiPath('/api/v1/prefixes')"
+              :result="{
+                'acl':'http://www.w3.org/ns/auth/acl#',
+                'as':'https://www.w3.org/ns/activitystreams#',
+                'bibo':'http://purl.org/ontology/bibo/',
+                'cc':'http://creativecommons.org/ns#',
+                'cert':'http://www.w3.org/ns/auth/cert#',
+                'cnt':'http://www.w3.org/2011/content#',
+                'constant':'http://qudt.org/vocab/constant/',
+                '…': '…'
+              }" />
 
           </div>
         </section>

--- a/pages/api.vue
+++ b/pages/api.vue
@@ -8,7 +8,7 @@
               RDF Prefix Resolve API
             </h1>
 
-            <p>We provide two API endpoints:</p>
+            <p>We provide the following API endpoints:</p>
 
             <ul>
               <li><a href="#expand-endpoint"><code>/api/v1/expand?q=…</code></a></li>

--- a/test/e2e/integration/api_spec.js
+++ b/test/e2e/integration/api_spec.js
@@ -214,5 +214,13 @@ describe('/api/v1', () => {
         })
       })
     })
+    describe('prefixes', () => {
+      it('get a list of prefixes', () => {
+        cy.request('/api/v1/prefixes').then((response) => {
+          expect(response.status).to.eq(200)
+          expect(Object.entries(response.body).length).to.be.greaterThan(0)
+        })
+      })
+    })
   })
 })


### PR DESCRIPTION
This new API endpoint (`/api/v1/prefixes`) will be useful for replacing the https://prefix.cc/popular/all.file.json endpoint used by YASGUI instances.